### PR TITLE
Handle R26 Pid format

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684580438,
-        "narHash": "sha256-LUPswmDn6fXP3lEBJFA2Id8PkcYDgzUilevWackYVvQ=",
+        "lastModified": 1699291058,
+        "narHash": "sha256-5ggduoaAMPHUy4riL+OrlAZE14Kh7JWX4oLEs22ZqfU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7dc71aef32e8faf065cb171700792cf8a65c152d",
+        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -8,7 +8,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        beamPkgs = pkgs.beam.packagesWith pkgs.beam.interpreters.erlangR23;
+        beamPkgs = pkgs.beam.packagesWith pkgs.beam.interpreters.erlangR26;
         inCI = builtins.getEnv "CI" != "";
       in
       rec {

--- a/src/erl2json.erl
+++ b/src/erl2json.erl
@@ -172,12 +172,16 @@ stdout(IO) ->
 pre_encode_pids(Str) when is_list(Str) ->
     re:replace(Str, "(<[0-9]+\.[0-9]+\.[0-9]+>)", "{pid,\"\\1\"}", [{return, list}, global]).
 
+pre_encode_r26_pids(Str) when is_list(Str) ->
+    re:replace(Str, "(<.*@.*\.[0-9]+\.[0-9]+>)", "{pid,\"\\1\"}", [{return, list}, global]).  
+
 pre_encode_bit_strings(Str) when is_list(Str) ->
     re:replace(Str, "<<([0-9 ,]*)>>", "{bit_string,[\\1]}", [{return, list}, global]).
 
 pre_encode(Str) ->
     lists:foldl(fun(F, Acc) -> F(Acc) end, Str, [
         fun pre_encode_pids/1,
+        fun pre_encode_r26_pids/1,
         fun pre_encode_bit_strings/1
     ]).
 

--- a/test/fixture/complex_erlang_object.json
+++ b/test/fixture/complex_erlang_object.json
@@ -22,6 +22,10 @@
       {
         "key1": { "type": "binary", "value": "dmFsdWU=" },
         "key2": { "type": "bit_string", "value": [2] }
+      },
+      {
+        "type": "tuple",
+        "values": [{ "type": "pid", "value": "<core1@crimson.local.1775.0>" }]
       }
     ]
   ]

--- a/test/fixture/complex_erlang_object.json
+++ b/test/fixture/complex_erlang_object.json
@@ -25,7 +25,8 @@
       },
       {
         "type": "tuple",
-        "values": [{ "type": "pid", "value": "<core1@crimson.local.1775.0>" }]
+        "record":"erlang_26_pid",
+        "values": [{ "type": "pid", "value": "<core1@alpha.local.1775.0>"}]
       }
     ]
   ]

--- a/test/fixture/complex_erlang_object.txt
+++ b/test/fixture/complex_erlang_object.txt
@@ -1,5 +1,6 @@
 {ok, [
     {my_record, "STRING", <7217.891.0>, undefined, 0, false, [{key1, "value"}, {key2, 123}]},
     {"data", 1234, undefined},
-    #{<<"key1">> => <<"value">>, <<"key2">> => <<2>>}
+    #{<<"key1">> => <<"value">>, <<"key2">> => <<2>>},
+    {erlang_26_pid, <core1@crimson.local.1775.0>}
 ]}

--- a/test/fixture/complex_erlang_object.txt
+++ b/test/fixture/complex_erlang_object.txt
@@ -2,5 +2,5 @@
     {my_record, "STRING", <7217.891.0>, undefined, 0, false, [{key1, "value"}, {key2, 123}]},
     {"data", 1234, undefined},
     #{<<"key1">> => <<"value">>, <<"key2">> => <<2>>},
-    {erlang_26_pid, <core1@crimson.local.1775.0>}
+    {erlang_26_pid, <core1@alpha.local.1775.0>}
 ]}


### PR DESCRIPTION
erl2json does not recognize the follow pid format:

```erlang
<core1@crimson.local.1775.0>
```